### PR TITLE
pyqt and qtpy are not pip pkg but conda

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,15 @@ classifiers = [
 ]
 dynamic = ["version", "readme"]
 dependencies = [
+]
+
+# section specific to conda-only distributed package (not used by pip yet)
+[tool.conda.environment]
+channels = [
+  "openalea3",
+  "conda-forge"
+]
+dependencies = [
   "qtpy",
   "pyqt",
 ]


### PR DESCRIPTION
therefore the documentation cannot be built because pip try to install pyqt, etc.